### PR TITLE
Fixed read mode

### DIFF
--- a/Customer_billing_system.c
+++ b/Customer_billing_system.c
@@ -93,7 +93,7 @@ void bill()
 	scanf("%d",&na);
 	printf("\n");
 	FILE *fp;
-	fp=fopen("Records.txt","w");
+	fp=fopen("Records.txt","r");
 	FILE *fptr;
 	fptr=fopen("temp.txt","w");
 	while(!(feof(fp)))


### PR DESCRIPTION
Fixed:

```bash
Customer_billing_system.c:102:3: error: Read operation on a file that was opened only for writing. [readWriteOnlyFile]
  fscanf(fp,"%d",&item.productno);
  ^
Customer_billing_system.c:103:3: error: Read operation on a file that was opened only for writing. [readWriteOnlyFile]
  fscanf(fp,"%s",item.productname);
  ^
Customer_billing_system.c:104:3: error: Read operation on a file that was opened only for writing. [readWriteOnlyFile]
  fscanf(fp,"%d",&item.quantity);
  ^
Customer_billing_system.c:105:3: error: Read operation on a file that was opened only for writing. [readWriteOnlyFile]
  fscanf(fp,"%d",&item.price);
  ^
```